### PR TITLE
Added Heat templates and instructions for stable/mitaka.

### DIFF
--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/README.md
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/README.md
@@ -1,0 +1,10 @@
+# heat-templates
+
+In this directory you will find Heat templates and configuration instructions
+required to use Barbican for encrypted Cinder volumes, and for storing Magnum
+clusters' and Neutron load balancer's SSL certificates. 
+
+The templates have been tested on OpenStack Mitaka (SUSE OpenStack Cloud 7) and
+OpenStack `master` (Devstack), which should apply to Newton 1:1. You will find
+the templates and everything needed to instantiate them in the mitaka/ and
+newton/ subdirectories, respectively.

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/README.md
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/README.md
@@ -18,3 +18,8 @@ You will find commented configuration snippets for each of these files in the
 `etc/` subdirectory. Both Heat templates contain a comment with an example Heat
 client invocation at the top. You will probably have to modify this slighly for
 your own use.
+
+For encrypted Cinder volumes to work through Heat, you will also need to apply
+the patch attached to this bug:
+
+https://bugs.launchpad.net/cinder/+bug/1631078

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/README.md
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/README.md
@@ -1,0 +1,20 @@
+# Heat templates for stable/mitaka
+
+In this directory you will find the following Heat templates:
+
+* *cinder-encrypted.yaml:* builds an instance and attaches an encrypted Cinder volume to it
+* *lbaas.yaml:* builds two instances behind a SSL enabled keystore
+
+For these Heat templates to work, you will need to adapt some configuration
+settings in the following files:
+
+* `cinder.conf`
+* `heat.conf`
+* `nova.conf`
+* `neutron.conf`
+* `neutron_lbaas.conf`
+
+You will find commented configuration snippets for each of these files in the
+`etc/` subdirectory. Both Heat templates contain a comment with an example Heat
+client invocation at the top. You will probably have to modify this slighly for
+your own use.

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/cinder-encrypted.yaml
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/cinder-encrypted.yaml
@@ -1,0 +1,153 @@
+
+heat_template_version: 2015-10-15
+
+
+parameters:
+  floating_network:
+    type: string
+    default: floating
+  image:
+    type: string
+    default: cirros-0.3.4
+  flavor:
+    type: string
+    default: m1.tiny
+  key_name:
+    type: string
+    default: mykey
+    description: |
+      This keypair needs to exist in Nova. Create as follows (assuming your SSH
+      public key is in ~/.ssh/id_rsa.pub):
+
+      nova keypair-add --pub-key ~/.ssh/id_rsa.pub mykey
+
+
+resources:
+
+  mynetwork:
+    type: OS::Neutron::Net
+    properties:
+      name: mynet
+
+
+  mysubnet:
+    type: OS::Neutron::Subnet
+    properties:
+      cidr: 10.0.0.1/24
+      name: mysubnet
+      network:
+        get_resource: mynetwork
+
+  # Note: this can only created if heat-engine uses an adminURL for its Cinder client
+  # cinder type-create encrypted
+#  myvolumetype:
+#    type: OS::Cinder::VolumeType
+#    properties:
+#      name: encrypted
+#      is_public: true
+
+  # Note: this can only created if heat-engine uses an adminURL for its Cinder client
+  # cinder encryption-type-create encrypted nova.volume.encryptors.luks.LuksEncryptor
+#  encryption_type:
+#    type: OS::Cinder::EncryptedVolumeType
+#    properties:
+#      volume_type: { get_resource: myvolumetype }
+#      provider: nova.volume.encryptors.luks.LuksEncryptor
+#
+
+  # This resource may trigger a 403 from two sources (both will be visible in
+  # cinder-api.log):
+  #   * Keystone, if the fix for https://bugs.launchpad.net/cinder/+bug/1631078
+  #     is not applied to your cloud
+  #
+  #   * Barbican, if the setting trusts_delegated_roles in heat.conf is not either
+  #       1) Empty (the default setting)
+  #       2) A list of roles that includes either `creator` role used by
+  #          Barbican to determine whether a user is allowed to create an Order
+  #          resource or the `admin` role.
+  #     In the second case, the user instantiating this Heat template must have
+  #     all roles mentioned in trusts_delegated_roles.
+
+  myvolume:
+    type: OS::Cinder::Volume
+    properties:
+      name: myencryptedvolume
+      size: 1
+      volume_type: encrypted
+
+  myserver:
+    type: OS::Nova::Server
+    properties:
+      name: myserver
+      config_drive: true
+      flavor: { get_param: flavor }
+      image: { get_param: image }
+      key_name: { get_param: key_name }
+      networks:
+        - port: { get_resource: myport }
+      user_data_format: RAW
+      user_data: |
+        #!/bin/sh
+        echo 'Hello, World' >> /etc/motd
+
+  myvolumeattachment:
+    type: OS::Cinder::VolumeAttachment
+    properties:
+      instance_uuid: { get_resource: myserver }
+      volume_id: { get_resource: myvolume }
+
+
+  router:
+    type: OS::Neutron::Router
+    properties:
+      external_gateway_info:
+        network:
+          get_param: floating_network
+
+
+  router_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: { get_resource: router }
+      subnet: { get_resource: mysubnet }
+
+
+  myfloatingip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      port_id: { get_resource: myport }
+      floating_network:
+        get_param: floating_network
+
+
+  allow_inbound:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      description: "Allow inbound SSH and ICMP traffic"
+      name: allow SSH and ICMP from anywhere
+      rules:
+        - direction: ingress
+          remote_ip_prefix: 0.0.0.0/0
+          protocol: tcp
+          port_range_min: 22
+          port_range_max: 22
+        - remote_ip_prefix: 0.0.0.0/0
+          protocol: icmp
+
+
+  myport:
+    type: OS::Neutron::Port
+    properties:
+      network:
+        get_resource: mynetwork
+      security_groups:                # NEW
+        - get_resource: allow_inbound # NEW
+
+
+outputs:
+  floating_ip:
+    value:
+      get_attr:
+        - myfloatingip
+        - floating_ip_address
+

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/cinder-encrypted.yaml
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/cinder-encrypted.yaml
@@ -1,4 +1,4 @@
-
+# Example invocation: heat stack-create --poll -f cinder-encrypted.yaml cinder-encrypted
 heat_template_version: 2015-10-15
 
 
@@ -40,20 +40,20 @@ resources:
 
   # Note: this can only created if heat-engine uses an adminURL for its Cinder client
   # cinder type-create encrypted
-#  myvolumetype:
-#    type: OS::Cinder::VolumeType
-#    properties:
-#      name: encrypted
-#      is_public: true
+  myvolumetype:
+    type: OS::Cinder::VolumeType
+    properties:
+      name: encrypted
+      is_public: true
 
   # Note: this can only created if heat-engine uses an adminURL for its Cinder client
   # cinder encryption-type-create encrypted nova.volume.encryptors.luks.LuksEncryptor
-#  encryption_type:
-#    type: OS::Cinder::EncryptedVolumeType
-#    properties:
-#      volume_type: { get_resource: myvolumetype }
-#      provider: nova.volume.encryptors.luks.LuksEncryptor
-#
+  encryption_type:
+    type: OS::Cinder::EncryptedVolumeType
+    properties:
+      volume_type: { get_resource: myvolumetype }
+      provider: nova.volume.encryptors.luks.LuksEncryptor
+
 
   # This resource may trigger a 403 from two sources (both will be visible in
   # cinder-api.log):
@@ -73,7 +73,7 @@ resources:
     properties:
       name: myencryptedvolume
       size: 1
-      volume_type: encrypted
+      volume_type: { get_resource: myvolumetype }
 
   myserver:
     type: OS::Nova::Server

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/etc/cinder.conf
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/etc/cinder.conf
@@ -1,0 +1,12 @@
+# Note: These settings need to be present on the Cinder API nodes and on all
+#       nodes running cinder-volume. Restart cinder-volume and cinder-api after
+#       modifying cinder.conf.
+
+[keymgr]
+api_class = cinder.keymgr.barbican.BarbicanKeyManager
+
+# Keystone publicURL with version appended
+encryption_auth_url = http://192.168.232.2:5000/v3
+
+# Barbican internalURL with version appended
+encryption_api_url = http://192.168.232.2:9311/v1

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/etc/heat.conf
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/etc/heat.conf
@@ -1,0 +1,9 @@
+# Note: these settings need to be present on every node running heat-api.
+#       Restart heat-engine after modifying heat.conf.
+[DEFAULT]
+# This setting needs to remain at its default value (empty list of roles)
+trusts_delegated_roles =
+
+[clients_cinder]
+# This setting needs to remain at its default value (<None>)
+#endpoint_type=<None>

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/etc/nova.conf
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/etc/nova.conf
@@ -1,0 +1,8 @@
+# Note: These settings need to be present on all nodes running nova-compute.
+#       Restart nova-compute after modifying nova.conf.
+[barbican]
+# Barbican publicURL with version appended
+endpoint_template = http://192.168.232.2:9311/v1/
+ 
+[keymgr]
+api_class = nova.keymgr.barbican.BarbicanKeyManager

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
@@ -240,6 +240,8 @@ resources:
 
 outputs:
 
+  lb_ip:
+    value: { get_attr: [ floating_ip, floating_ip_address ] }
   lburl:
     value:
       str_replace:

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
@@ -220,7 +220,7 @@ resources:
   listener:
     type: OS::Neutron::LBaaS::Listener
     properties:
-      default_tls_container_ref: tls_container
+      default_tls_container_ref: { get_resource: tls_container }
       loadbalancer: { get_resource: loadbalancer }
       protocol: TERMINATED_HTTPS
       protocol_port: { get_param: lb_port }

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
@@ -1,3 +1,7 @@
+# heat stack-create --poll -f heat-templates/hot/lbaasv2/lb_group.yaml -P public_key="$(cat server.crt)" -P private_key="$(cat server.key)" -P public_network=floating -P image=cirros-0.3.4-x86_64-tempest-machine -P flavor=m1.tiny lb_ssl
+# Note: You will need to generate SSL keys as documented in
+#         https://wiki.openstack.org/wiki/Network/LBaaS/docs/how-to-create-tls-loadbalancer#Create_certificate_chain_and_key.
+#       and be in the directory where you created the keys for this to work.
 heat_template_version: 2015-10-15
 
 description: A Group of Load Balanced Servers

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
@@ -1,4 +1,5 @@
-# heat stack-create --poll -f heat-templates/hot/lbaasv2/lb_group.yaml -P public_key="$(cat server.crt)" -P private_key="$(cat server.key)" -P public_network=floating -P image=cirros-0.3.4-x86_64-tempest-machine -P flavor=m1.tiny lb_ssl
+# Example invocation:
+#   heat stack-create --poll -f heat-templates/hot/lbaasv2/lb_group.yaml -P public_key="$(cat server.crt)" -P private_key="$(cat server.key)" -P public_network=floating -P image=cirros-0.3.4-x86_64-tempest-machine -P flavor=m1.tiny lb_ssl
 # Note: You will need to generate SSL keys as documented in
 #         https://wiki.openstack.org/wiki/Network/LBaaS/docs/how-to-create-tls-loadbalancer#Create_certificate_chain_and_key.
 #       and be in the directory where you created the keys for this to work.
@@ -113,8 +114,8 @@ resources:
           template: |
             #!/bin/sh
             set -x
-            exec 2>&1 > /var/log/user-data.log
-            Body="Works member $(hostname)
+            exec > /var/log/user-data.log 2>&1
+            Body="Works member $(hostname)"
             Response="HTTP/1.1 200 OK\r\nContent-Length: ${#Body}\r\n\r\n$Body"
             while true ; do echo -e $Response | sudo nc -llp PORT; done
           params:
@@ -158,8 +159,8 @@ resources:
           template: |
             #!/bin/sh
             set -x
-            exec 2>&1 > /var/log/user-data.log
-            Body="Works member $(hostname)
+            exec > /var/log/user-data.log 2>&1
+            Body="Works member $(hostname)"
             Response="HTTP/1.1 200 OK\r\nContent-Length: ${#Body}\r\n\r\n$Body"
             while true ; do echo -e $Response | sudo nc -llp PORT; done
           params:

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
@@ -3,6 +3,13 @@
 # Note: You will need to generate SSL keys as documented in
 #         https://wiki.openstack.org/wiki/Network/LBaaS/docs/how-to-create-tls-loadbalancer#Create_certificate_chain_and_key.
 #       and be in the directory where you created the keys for this to work.
+# Once the stack has been created, you can verify the load balancer works as
+# follows (you'll need to be root or have some other means of pointing the DNS
+# for lb.example.com at the load balancer IP):
+#
+# sed -i '/lb\.example\.com.*/d' /etc/hosts; echo "$(heat output-show lb_ssl lb_ip | sed 's/"//g')  lb.example.com" >> /etc/hosts
+# curl --cacert ca.pem https://lb.example.com
+
 heat_template_version: 2015-10-15
 
 description: A Group of Load Balanced Servers

--- a/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
+++ b/hiding-in-the-clouds_secret-management-with-openstack-barbican/heat-templates/mitaka/lbaas.yaml
@@ -1,0 +1,247 @@
+heat_template_version: 2015-10-15
+
+description: A Group of Load Balanced Servers
+
+parameters:
+
+  app_port:
+    type: number
+    default: 4443
+    description: Port used by the servers
+  flavor:
+    type: string
+    description: Flavor used for servers
+    constraints:
+    - custom_constraint: nova.flavor
+  image:
+    type: string
+    description: Image used for servers
+    constraints:
+    - custom_constraint: glance.image
+  lb_port:
+    type: number
+    default: 443
+    description: Port used by the load balancer
+  public_network:
+    type: string
+    description: Network used by the load balancer
+    constraints:
+    - custom_constraint: neutron.network
+  private_key:
+    type: string
+    description: The server certificate's private key
+  public_key:
+    type: string
+    description: The server certificate's public key
+
+
+resources:
+
+  router:
+    type: OS::Neutron::Router
+    properties:
+      external_gateway_info:
+        network:
+          get_param: public_network
+
+  lb_network:
+    type: OS::Neutron::Net
+    properties:
+      name: lb_network
+
+  lb_subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      cidr: 10.0.1.0/24
+      name: lb_subnet
+      network:
+        get_resource: lb_network
+
+  private_network:
+    type: OS::Neutron::Net
+    properties:
+      name: private_network
+
+  private_subnet:
+    type: OS::Neutron::Subnet
+    properties:
+      cidr: 10.0.2.0/24
+      name: private_subnet
+      network:
+        get_resource: private_network
+
+  lb_router_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: { get_resource: router }
+      subnet: { get_resource: private_subnet }
+
+  private_router_interface:
+    type: OS::Neutron::RouterInterface
+    properties:
+      router: { get_resource: router }
+      subnet: { get_resource: lb_subnet }
+
+  sec_group:
+    type: OS::Neutron::SecurityGroup
+    properties:
+      rules:
+      - remote_ip_prefix: 0.0.0.0/0
+        protocol: tcp
+        port_range_min: { get_param: app_port }
+        port_range_max: { get_param: app_port }
+      # Only for accessing instances during debugging/testing: do NOT do this
+      # in production:
+      - remote_ip_prefix: 0.0.0.0/0
+        protocol: tcp
+        port_range_min: 22
+        port_range_max: 22
+
+  server1:
+    type: OS::Nova::Server
+    properties:
+      image: { get_param: image }
+      flavor: { get_param: flavor }
+      networks: [{ port: { get_resource: server1_port }}]
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          template: |
+            #!/bin/sh
+            set -x
+            exec 2>&1 > /var/log/user-data.log
+            Body="Works member $(hostname)
+            Response="HTTP/1.1 200 OK\r\nContent-Length: ${#Body}\r\n\r\n$Body"
+            while true ; do echo -e $Response | sudo nc -llp PORT; done
+          params:
+            PORT: { get_param: app_port }
+
+  server1_port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_resource: private_network }
+      security_groups:
+        - get_resource: sec_group
+
+  # Only for accessing instances during debugging/testing: do NOT assign
+  # floating IPs to servers behind the load balancer in production.
+  server1_float:
+    type: OS::Neutron::FloatingIP
+    depends_on: private_router_interface
+    properties:
+      port_id: { get_resource: server1_port }
+      floating_network: { get_param: public_network }
+
+
+  pool_member1:
+    type: OS::Neutron::LBaaS::PoolMember
+    properties:
+      pool: { get_resource: pool }
+      address: { get_attr: [ server1, first_address ]}
+      protocol_port: { get_param: app_port }
+      subnet: { get_resource: lb_subnet }
+
+  server2:
+    type: OS::Nova::Server
+    properties:
+      image: { get_param: image }
+      flavor: { get_param: flavor }
+      networks: [{ port: { get_resource: server2_port }}]
+      security_groups: [{ get_resource: sec_group }]
+      user_data_format: RAW
+      user_data:
+        str_replace:
+          template: |
+            #!/bin/sh
+            set -x
+            exec 2>&1 > /var/log/user-data.log
+            Body="Works member $(hostname)
+            Response="HTTP/1.1 200 OK\r\nContent-Length: ${#Body}\r\n\r\n$Body"
+            while true ; do echo -e $Response | sudo nc -llp PORT; done
+          params:
+            PORT: { get_param: app_port }
+
+  server2_port:
+    type: OS::Neutron::Port
+    properties:
+      network: { get_resource: private_network }
+      security_groups:
+        - get_resource: sec_group
+
+  # Only for accessing instances during debugging/testing: do NOT assign
+  # floating IPs to servers behind the load balancer in production.
+  server2_float:
+    type: OS::Neutron::FloatingIP
+    depends_on: private_router_interface
+    properties:
+      port_id: { get_resource: server2_port }
+      floating_network: { get_param: public_network }
+
+  pool_member2:
+    type: OS::Neutron::LBaaS::PoolMember
+    properties:
+      pool: { get_resource: pool }
+      address: { get_attr: [ server2, first_address ]}
+      protocol_port: { get_param: app_port }
+      subnet: { get_resource: lb_subnet }
+
+  pool:
+    type: OS::Neutron::LBaaS::Pool
+    properties:
+      lb_algorithm: ROUND_ROBIN
+      protocol: HTTP
+      listener: { get_resource: listener }
+
+  server_public_key:
+   type: OS::Barbican::Secret
+   properties:
+     name: server_public_key
+     payload: { get_param: public_key }
+     payload_content_type: text/plain
+
+  server_private_key:
+   type: OS::Barbican::Secret
+   properties:
+     name: server_private_key
+     payload: { get_param: private_key }
+     payload_content_type: text/plain
+
+  tls_container:
+   type: OS::Barbican::CertificateContainer
+   properties:
+     certificate_ref: { get_resource: server_public_key }
+     private_key_ref: { get_resource: server_private_key }
+     name: tls_container
+
+  listener:
+    type: OS::Neutron::LBaaS::Listener
+    properties:
+      default_tls_container_ref: tls_container
+      loadbalancer: { get_resource: loadbalancer }
+      protocol: TERMINATED_HTTPS
+      protocol_port: { get_param: lb_port }
+
+  loadbalancer:
+    type: OS::Neutron::LBaaS::LoadBalancer
+    depends_on: lb_router_interface
+    properties:
+      vip_subnet: { get_resource: lb_subnet }
+
+  floating_ip:
+    type: OS::Neutron::FloatingIP
+    properties:
+      floating_network: { get_param: public_network }
+      port_id: { get_attr: [loadbalancer, vip_port_id ]}
+
+outputs:
+
+  lburl:
+    value:
+      str_replace:
+        template: https://IP_ADDRESS:PORT
+        params:
+          IP_ADDRESS: { get_attr: [ floating_ip, floating_ip_address ] }
+          PORT: { get_param: lb_port }
+    description: >
+      This URL is the "external" URL that can be used to access the
+      load balancer.


### PR DESCRIPTION
This pull request contains Heat templates for encrypted Cinder volumes and SSL enabled LBaaS on `stable/mitaka`. The Heat templates and configuration for Cinder and Neutron have been tested and work. The Heat template for LBaaS should be fine, but there may still be some configuration issues and/or patches required. We are currently investigating the problem (it worked a couple of times but then `neutron_lbaas` started getting 404s from the Barbican API).

Things outside the scope of this pull request:
- Heat templates for `master` (these shouldn't require much modification, if any)
- Neutron related configuration changes
- Configuration changes for `master`
- A Heat template for Magnum. I wrote one a while back, but it ceased working as of a few weeks ago. I won't add this unless I figure out what broke it. It's likely to be due to configuration changes, though.
